### PR TITLE
Quality parsing support

### DIFF
--- a/include/FastxParser.hpp
+++ b/include/FastxParser.hpp
@@ -65,6 +65,13 @@ struct ReadSeq {
     ~ReadSeq() {}
 };
 
+struct ReadQual {
+     std::string seq;
+     std::string name;
+     std::string qual;
+     ~ReadQual() {}
+ };
+  
 struct ReadPair {
   ReadSeq first;
   ReadSeq second;

--- a/include/FastxParser.hpp
+++ b/include/FastxParser.hpp
@@ -76,6 +76,11 @@ struct ReadPair {
   ReadSeq first;
   ReadSeq second;
 };
+  
+struct ReadQualPair {
+  ReadQual first;
+  ReadQual second;
+};
 
 template <typename T> class ReadChunk {
 public:


### PR DESCRIPTION
New templates created for quality support in the parser with the class name `ReadQual`.
Currently only supported for Single-end read.