### PR TITLE
Resolve Issue #48 - aarch64 use of wfe in cpuRelax

### DIFF
--- a/include/FastxParserThreadUtils.hpp
+++ b/include/FastxParserThreadUtils.hpp
@@ -36,10 +36,10 @@ ALWAYS_INLINE static void cpuRelax() {
 #elif defined(__i386__) || defined(__x86_64__)
   asm volatile("pause");
 #elif defined(__aarch64__)
-  asm volatile("wfe");
+  asm volatile("isb");
 #elif defined(__armel__) || defined(__ARMEL__)
   asm volatile ("nop" ::: "memory");
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(__arm__) 
   __asm__ __volatile__ ("yield" ::: "memory");
 #elif defined(__ia64__)  // IA64
   __asm__ __volatile__ ("hint @pause");


### PR DESCRIPTION

    Replace aarch64 WFE instruction usage with ISB.
    
    WFE stalls the process for an indeterminate period of time, yielding
    slower perfomance when more threads are active than the actual core count.
    
    As a side effect of implementation, ISB stalls execution for some tens
    of cycles which (when executed in a loop) decreases memory contention and
    thus improves multithreaded performance.
    
    Resolves #48.
